### PR TITLE
Updated parser to support Webex WebVTT format including speaker name

### DIFF
--- a/subtitle_parser.py
+++ b/subtitle_parser.py
@@ -303,32 +303,43 @@ class WebVttParser(SrtParser):
         self.skip_blank_lines()
 
 
-def render_html(subtitles, file_out):
+def render_html(subtitles, file_out, *, show_name=None):
     import html
 
     for subtitle in subtitles:
+        name = ''
+        if show_name is not False and subtitle.name:
+            name = ' ' + html.escape(subtitle.name)
         print(
-            "<p>{ts} {text}</p>".format(
+            "<p>{ts}{name} {text}</p>".format(
                 ts=format_timestamp(subtitle.start),
-                name=html.escape(subtitle.name),
+                name=name,
                 text=html.escape(subtitle.text).replace('\n', '<br>'),
             ),
             file=file_out,
         )
 
 
-def render_csv(subtitles, file_out):
+def render_csv(subtitles, file_out, *, show_name=None):
     import csv
 
     writer = csv.writer(file_out)
-    writer.writerow(['start', 'end', 'name', 'text'])
+    writer.writerow(
+        ['start', 'end']
+        + (['name'] if show_name else [])
+        + ['text']
+    )
     for subtitle in subtitles:
-        writer.writerow([
-            format_timestamp(subtitle.start),
-            format_timestamp(subtitle.end),
-            subtitle.name,
-            subtitle.text,
-        ])
+        writer.writerow(
+            [
+                format_timestamp(subtitle.start),
+                format_timestamp(subtitle.end),
+            ]
+            + ([subtitle.name] if show_name else [])
+            + [
+                subtitle.text,
+            ]
+        )
 
 
 def main():
@@ -337,6 +348,16 @@ def main():
     arg_parser.add_argument('--input-charset', default=None)
     arg_parser.add_argument('input', help="Input subtitles")
     arg_parser.add_argument('--output', '-o', help="Output file name")
+    arg_parser.add_argument(
+        '--with-name',
+        default=None, action='store_true', dest='show_name',
+        help="Show the speaker's name",
+    )
+    arg_parser.add_argument(
+        '--without-name',
+        default=None, action='store_false', dest='show_name',
+        help="Don't show the speaker's name",
+    )
 
     args = arg_parser.parse_args()
 
@@ -445,7 +466,7 @@ def main():
         )
 
     # Write output
-    render_func(parser.subtitles, file_output)
+    render_func(parser.subtitles, file_output, show_name=args.show_name)
     file_output.close()
 
 

--- a/subtitle_parser.py
+++ b/subtitle_parser.py
@@ -25,7 +25,7 @@ def format_timestamp(ts):
 
 
 class Subtitle(object):
-    def __init__(self, number, name, start, end, text):
+    def __init__(self, number, start, end, text, *, name=None):
         self.number = number
         self.name = name
         self.start = start
@@ -168,8 +168,9 @@ class SrtParser(object):
             )
 
         self.subtitles.append(Subtitle(
-            subtitle_number, name, start, end,
+            subtitle_number, start, end,
             '\n'.join(lines),
+            name=name,
         ))
 
         self.skip_blank_lines()

--- a/tests.py
+++ b/tests.py
@@ -21,9 +21,9 @@ class TestSrtSubtitles(unittest.TestCase):
         ''')))
         parser.parse()
         self.assertEqual(parser.subtitles, [
-            Subtitle(1, None, (0, 0, 0, 123), (0, 0, 3, 456), 'Hi there'),
+            Subtitle(1, (0, 0, 0, 123), (0, 0, 3, 456), 'Hi there'),
             Subtitle(
-                2, None, (0, 1, 4, 843), (0, 1, 5, 428),
+                2, (0, 1, 4, 843), (0, 1, 5, 428),
                 'This is an example of a\nsubtitle file in SRT format',
             ),
         ])
@@ -46,9 +46,9 @@ class TestSrtSubtitles(unittest.TestCase):
         ''')))
         parser.parse()
         self.assertEqual(parser.subtitles, [
-            Subtitle(2, None, (0, 0, 0, 123), (0, 0, 3, 456), 'Hi there'),
+            Subtitle(2, (0, 0, 0, 123), (0, 0, 3, 456), 'Hi there'),
             Subtitle(
-                5, None, (0, 1, 4, 843), (0, 1, 5, 428),
+                5, (0, 1, 4, 843), (0, 1, 5, 428),
                 'This is an example of a\nsubtitle file in SRT format',
             ),
         ])
@@ -142,9 +142,9 @@ class TestWebVttSubtitles(unittest.TestCase):
         ''')))
         parser.parse()
         self.assertEqual(parser.subtitles, [
-            Subtitle(1, None, (0, 0, 0, 123), (0, 0, 3, 456), 'Hi there'),
+            Subtitle(1, (0, 0, 0, 123), (0, 0, 3, 456), 'Hi there'),
             Subtitle(
-                None, None, (0, 1, 4, 843), (0, 1, 5, 428),
+                None, (0, 1, 4, 843), (0, 1, 5, 428),
                 'This is an example of a\nsubtitle file in SRT format',
             ),
         ])
@@ -191,12 +191,12 @@ class TestWebVttSubtitles(unittest.TestCase):
         ''')))
         parser.parse()
         self.assertEqual(parser.subtitles, [
-            Subtitle(1, None, (0, 0, 0, 123), (0, 0, 1, 456), 'number'),
-            Subtitle(None, None, (0, 0, 2, 0), (0, 0, 3, 0), 'no number'),
-            Subtitle(None, None, (0, 0, 4, 0), (0, 0, 5, 0), 'no number'),
-            Subtitle(2, None, (0, 0, 6, 0), (0, 0, 7, 0), 'number'),
-            Subtitle(4, None, (0, 0, 8, 0), (0, 0, 9, 0), 'wrong number'),
-            Subtitle(None, None, (0, 0, 10, 0), (0, 0, 11, 0), 'no number'),
+            Subtitle(1, (0, 0, 0, 123), (0, 0, 1, 456), 'number'),
+            Subtitle(None, (0, 0, 2, 0), (0, 0, 3, 0), 'no number'),
+            Subtitle(None, (0, 0, 4, 0), (0, 0, 5, 0), 'no number'),
+            Subtitle(2, (0, 0, 6, 0), (0, 0, 7, 0), 'number'),
+            Subtitle(4, (0, 0, 8, 0), (0, 0, 9, 0), 'wrong number'),
+            Subtitle(None, (0, 0, 10, 0), (0, 0, 11, 0), 'no number'),
         ])
         self.assertEqual(parser.warnings, [
             (6, 'Subtitle numbers stop line 7'),
@@ -246,14 +246,14 @@ class TestWebVttSubtitles(unittest.TestCase):
         ''')))
         parser.parse()
         self.assertEqual(parser.subtitles, [
-            Subtitle(1, "Shmo, Jonathan", (0, 11, 3, 989), (0, 11, 7, 169), "Another option is just to pop the tool tip."),
-            Subtitle(2, "Doe, Kevin", (0, 11, 7, 169), (0, 11, 16, 619), "Right. That's okay. That's I'm okay with that. See like that achieve that goal. The outcome is I want people without having to click know what the behind the."),
-            Subtitle(3, "Shmo, Jonathan", (0, 11, 16, 619), (0, 11, 23, 369), 'Yep, yeah, we can just defaulted on for the 1st time.'),
-            Subtitle(4, "Doe, Kevin", (0, 11, 23, 369), (0, 11, 28, 679), 'Um, Paul, I think Paul had the hands up.'),
-            Subtitle(5, "Conf WA HQ B5 3A", (0, 11, 28, 679), (0, 11, 34, 649), 'That Paul, or is that monitor again? What is what is the difference for the user?'),
-            Subtitle(6, "Conf WA HQ B5 3A", (0, 11, 34, 649), (0, 11, 38, 429), "Whether there's Bluetooth connection."),
-            Subtitle(7, "Conf WA HQ B5 3A", (0, 11, 38, 429), (0, 11, 42, 929), "Or there's no Bluetooth connection because."),
-            Subtitle(8, "Conf WA HQ B5 3A", (0, 11, 42, 929), (0, 11, 47, 309), 'If you lose Bluetooth connection, you still have your GPS.'),
+            Subtitle(1, (0, 11, 3, 989), (0, 11, 7, 169), "Another option is just to pop the tool tip.", name="Shmo, Jonathan"),
+            Subtitle(2, (0, 11, 7, 169), (0, 11, 16, 619), "Right. That's okay. That's I'm okay with that. See like that achieve that goal. The outcome is I want people without having to click know what the behind the.", name="Doe, Kevin"),
+            Subtitle(3, (0, 11, 16, 619), (0, 11, 23, 369), "Yep, yeah, we can just defaulted on for the 1st time.", name="Shmo, Jonathan"),
+            Subtitle(4, (0, 11, 23, 369), (0, 11, 28, 679), "Um, Paul, I think Paul had the hands up.", name="Doe, Kevin"),
+            Subtitle(5, (0, 11, 28, 679), (0, 11, 34, 649), "That Paul, or is that monitor again? What is what is the difference for the user?", name="Conf WA HQ B5 3A"),
+            Subtitle(6, (0, 11, 34, 649), (0, 11, 38, 429), "Whether there's Bluetooth connection.", name="Conf WA HQ B5 3A"),
+            Subtitle(7, (0, 11, 38, 429), (0, 11, 42, 929), "Or there's no Bluetooth connection because.", name="Conf WA HQ B5 3A"),
+            Subtitle(8, (0, 11, 42, 929), (0, 11, 47, 309), "If you lose Bluetooth connection, you still have your GPS.", name="Conf WA HQ B5 3A"),
         ])
 
 

--- a/tests.py
+++ b/tests.py
@@ -21,9 +21,9 @@ class TestSrtSubtitles(unittest.TestCase):
         ''')))
         parser.parse()
         self.assertEqual(parser.subtitles, [
-            Subtitle(1, (0, 0, 0, 123), (0, 0, 3, 456), 'Hi there'),
+            Subtitle(1, None, (0, 0, 0, 123), (0, 0, 3, 456), 'Hi there'),
             Subtitle(
-                2, (0, 1, 4, 843), (0, 1, 5, 428),
+                2, None, (0, 1, 4, 843), (0, 1, 5, 428),
                 'This is an example of a\nsubtitle file in SRT format',
             ),
         ])
@@ -46,9 +46,9 @@ class TestSrtSubtitles(unittest.TestCase):
         ''')))
         parser.parse()
         self.assertEqual(parser.subtitles, [
-            Subtitle(2, (0, 0, 0, 123), (0, 0, 3, 456), 'Hi there'),
+            Subtitle(2, None, (0, 0, 0, 123), (0, 0, 3, 456), 'Hi there'),
             Subtitle(
-                5, (0, 1, 4, 843), (0, 1, 5, 428),
+                5, None, (0, 1, 4, 843), (0, 1, 5, 428),
                 'This is an example of a\nsubtitle file in SRT format',
             ),
         ])
@@ -142,9 +142,9 @@ class TestWebVttSubtitles(unittest.TestCase):
         ''')))
         parser.parse()
         self.assertEqual(parser.subtitles, [
-            Subtitle(1, (0, 0, 0, 123), (0, 0, 3, 456), 'Hi there'),
+            Subtitle(1, None, (0, 0, 0, 123), (0, 0, 3, 456), 'Hi there'),
             Subtitle(
-                None, (0, 1, 4, 843), (0, 1, 5, 428),
+                None, None, (0, 1, 4, 843), (0, 1, 5, 428),
                 'This is an example of a\nsubtitle file in SRT format',
             ),
         ])
@@ -191,18 +191,69 @@ class TestWebVttSubtitles(unittest.TestCase):
         ''')))
         parser.parse()
         self.assertEqual(parser.subtitles, [
-            Subtitle(1, (0, 0, 0, 123), (0, 0, 1, 456), 'number'),
-            Subtitle(None, (0, 0, 2, 0), (0, 0, 3, 0), 'no number'),
-            Subtitle(None, (0, 0, 4, 0), (0, 0, 5, 0), 'no number'),
-            Subtitle(2, (0, 0, 6, 0), (0, 0, 7, 0), 'number'),
-            Subtitle(4, (0, 0, 8, 0), (0, 0, 9, 0), 'wrong number'),
-            Subtitle(None, (0, 0, 10, 0), (0, 0, 11, 0), 'no number'),
+            Subtitle(1, None, (0, 0, 0, 123), (0, 0, 1, 456), 'number'),
+            Subtitle(None, None, (0, 0, 2, 0), (0, 0, 3, 0), 'no number'),
+            Subtitle(None, None, (0, 0, 4, 0), (0, 0, 5, 0), 'no number'),
+            Subtitle(2, None, (0, 0, 6, 0), (0, 0, 7, 0), 'number'),
+            Subtitle(4, None, (0, 0, 8, 0), (0, 0, 9, 0), 'wrong number'),
+            Subtitle(None, None, (0, 0, 10, 0), (0, 0, 11, 0), 'no number'),
         ])
         self.assertEqual(parser.warnings, [
             (6, 'Subtitle numbers stop line 7'),
             (13, 'Subtitle numbers (re)starts line 14'),
             (17, 'Subtitle number is 4, expected 3'),
             (20, 'Subtitle numbers stop line 21'),
+        ])
+
+    def test_webex_check(self):
+        import io
+        import textwrap
+
+        parser = WebVttParser(io.StringIO(textwrap.dedent('''\
+            WEBVTT
+
+            1 "Shmo, Jonathan" (1838608384)
+            00:11:03.989 --> 00:11:07.169
+            Another option is just to pop the tool tip.
+
+            2 "Doe, Kevin" (3768348160)
+            00:11:07.169 --> 00:11:16.619
+            Right. That's okay. That's I'm okay with that. See like that achieve that goal. The outcome is I want people without having to click know what the behind the.
+
+            3 "Shmo, Jonathan" (1838608384)
+            00:11:16.619 --> 00:11:23.369
+            Yep, yeah, we can just defaulted on for the 1st time.
+
+            4 "Doe, Kevin" (3768348160)
+            00:11:23.369 --> 00:11:28.679
+            Um, Paul, I think Paul had the hands up.
+
+            5 "Conf WA HQ B5 3A" (1129774080)
+            00:11:28.679 --> 00:11:34.649
+            That Paul, or is that monitor again? What is what is the difference for the user?
+
+            6 "Conf WA HQ B5 3A" (1129774080)
+            00:11:34.649 --> 00:11:38.429
+            Whether there's Bluetooth connection.
+
+            7 "Conf WA HQ B5 3A" (1129774080)
+            00:11:38.429 --> 00:11:42.929
+            Or there's no Bluetooth connection because.
+
+            8 "Conf WA HQ B5 3A" (1129774080)
+            00:11:42.929 --> 00:11:47.309
+            If you lose Bluetooth connection, you still have your GPS.
+        ''')))
+        parser.parse()
+        self.assertEqual(parser.subtitles, [
+            Subtitle(1, "Shmo, Jonathan", (0, 11, 3, 989), (0, 11, 7, 169), "Another option is just to pop the tool tip."),
+            Subtitle(2, "Doe, Kevin", (0, 11, 7, 169), (0, 11, 16, 619), "Right. That's okay. That's I'm okay with that. See like that achieve that goal. The outcome is I want people without having to click know what the behind the."),
+            Subtitle(3, "Shmo, Jonathan", (0, 11, 16, 619), (0, 11, 23, 369), 'Yep, yeah, we can just defaulted on for the 1st time.'),
+            Subtitle(4, "Doe, Kevin", (0, 11, 23, 369), (0, 11, 28, 679), 'Um, Paul, I think Paul had the hands up.'),
+            Subtitle(5, "Conf WA HQ B5 3A", (0, 11, 28, 679), (0, 11, 34, 649), 'That Paul, or is that monitor again? What is what is the difference for the user?'),
+            Subtitle(6, "Conf WA HQ B5 3A", (0, 11, 34, 649), (0, 11, 38, 429), "Whether there's Bluetooth connection."),
+            Subtitle(7, "Conf WA HQ B5 3A", (0, 11, 38, 429), (0, 11, 42, 929), "Or there's no Bluetooth connection because."),
+            Subtitle(8, "Conf WA HQ B5 3A", (0, 11, 42, 929), (0, 11, 47, 309), 'If you lose Bluetooth connection, you still have your GPS.'),
         ])
 
 

--- a/tests.py
+++ b/tests.py
@@ -218,7 +218,7 @@ class TestWebVttSubtitles(unittest.TestCase):
 
             2 "Doe, Kevin" (3768348160)
             00:11:07.169 --> 00:11:16.619
-            Right. That's okay. That's I'm okay with that. See like that achieve that goal. The outcome is I want people without having to click know what the behind the.
+            Right. That's okay. That's I'm okay with that.
 
             3 "Shmo, Jonathan" (1838608384)
             00:11:16.619 --> 00:11:23.369
@@ -230,7 +230,7 @@ class TestWebVttSubtitles(unittest.TestCase):
 
             5 "Conf WA HQ B5 3A" (1129774080)
             00:11:28.679 --> 00:11:34.649
-            That Paul, or is that monitor again? What is what is the difference for the user?
+            What is what is the difference for the user?
 
             6 "Conf WA HQ B5 3A" (1129774080)
             00:11:34.649 --> 00:11:38.429
@@ -246,14 +246,46 @@ class TestWebVttSubtitles(unittest.TestCase):
         ''')))
         parser.parse()
         self.assertEqual(parser.subtitles, [
-            Subtitle(1, (0, 11, 3, 989), (0, 11, 7, 169), "Another option is just to pop the tool tip.", name="Shmo, Jonathan"),
-            Subtitle(2, (0, 11, 7, 169), (0, 11, 16, 619), "Right. That's okay. That's I'm okay with that. See like that achieve that goal. The outcome is I want people without having to click know what the behind the.", name="Doe, Kevin"),
-            Subtitle(3, (0, 11, 16, 619), (0, 11, 23, 369), "Yep, yeah, we can just defaulted on for the 1st time.", name="Shmo, Jonathan"),
-            Subtitle(4, (0, 11, 23, 369), (0, 11, 28, 679), "Um, Paul, I think Paul had the hands up.", name="Doe, Kevin"),
-            Subtitle(5, (0, 11, 28, 679), (0, 11, 34, 649), "That Paul, or is that monitor again? What is what is the difference for the user?", name="Conf WA HQ B5 3A"),
-            Subtitle(6, (0, 11, 34, 649), (0, 11, 38, 429), "Whether there's Bluetooth connection.", name="Conf WA HQ B5 3A"),
-            Subtitle(7, (0, 11, 38, 429), (0, 11, 42, 929), "Or there's no Bluetooth connection because.", name="Conf WA HQ B5 3A"),
-            Subtitle(8, (0, 11, 42, 929), (0, 11, 47, 309), "If you lose Bluetooth connection, you still have your GPS.", name="Conf WA HQ B5 3A"),
+            Subtitle(
+                1, (0, 11, 3, 989), (0, 11, 7, 169),
+                "Another option is just to pop the tool tip.",
+                name="Shmo, Jonathan",
+            ),
+            Subtitle(
+                2, (0, 11, 7, 169), (0, 11, 16, 619),
+                "Right. That's okay. That's I'm okay with that.",
+                name="Doe, Kevin",
+            ),
+            Subtitle(
+                3, (0, 11, 16, 619), (0, 11, 23, 369),
+                "Yep, yeah, we can just defaulted on for the 1st time.",
+                name="Shmo, Jonathan",
+            ),
+            Subtitle(
+                4, (0, 11, 23, 369), (0, 11, 28, 679),
+                "Um, Paul, I think Paul had the hands up.",
+                name="Doe, Kevin",
+            ),
+            Subtitle(
+                5, (0, 11, 28, 679), (0, 11, 34, 649),
+                "What is what is the difference for the user?",
+                name="Conf WA HQ B5 3A",
+            ),
+            Subtitle(
+                6, (0, 11, 34, 649), (0, 11, 38, 429),
+                "Whether there's Bluetooth connection.",
+                name="Conf WA HQ B5 3A",
+            ),
+            Subtitle(
+                7, (0, 11, 38, 429), (0, 11, 42, 929),
+                "Or there's no Bluetooth connection because.",
+                name="Conf WA HQ B5 3A",
+            ),
+            Subtitle(
+                8, (0, 11, 42, 929), (0, 11, 47, 309),
+                "If you lose Bluetooth connection, you still have your GPS.",
+                name="Conf WA HQ B5 3A",
+            ),
         ])
 
 


### PR DESCRIPTION
Webex recordings add speaker name alongside the line number. This was causing the parser to fail. 
 - Added new member variable "name" to the Subtitle class to store the active speaker name. 
 - Filtered out the name alongside the line number to prevent parser malfunction.
 - Added "name" field throughout the code in order to prevent type mismatches. 
 - Added "name" to the HTML and CSV render functions in order to output the speaker name alongside the subtitles
 - Added a new test case `test_webex_check` to verify the implementation worked for Webex output
 - Fixed the other tests to take into account the new "name" field. 
 - Got all tests to run appropriately. 
 