### PR TITLE
Exclude tests and changelog from installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ classifiers = [
 ]
 
 include = [
-    "tests.py", "CHANGELOG.md",
+    { path = "tests.py", format = "sdist" },
+    { path = "CHANGELOG.md", format = "sdist" },
 ]
 
 [tool.poetry.urls]


### PR DESCRIPTION
Without this change, these files end up in site-packages